### PR TITLE
GustyDAG: Create a DAG in one line of code based on METADATA.yml

### DIFF
--- a/examples/gusty_tutorial/METADATA.yml
+++ b/examples/gusty_tutorial/METADATA.yml
@@ -1,0 +1,20 @@
+# This DAG lines up one-to-one with the Airflow tutorial:
+# https://airflow.apache.org/docs/stable/tutorial.html
+description: "A Gusty version of the DAG described by this Airflow tutorial: https://airflow.apache.org/docs/stable/tutorial.html"
+schedule_interval: "1 0 * * *"
+default_args:
+    owner: airflow
+    depends_on_past: false
+    start_date: !days_ago 1
+    email: airflow@example.com
+    email_on_failure: false
+    email_on_retry: false
+    retries: 1
+    retry_delay: !timedelta 'minutes: 5'
+#   queue: bash_queue
+#   pool: backfill
+#   priority_weight: 10
+#   end_date: !datetime [2016, 1, 1]
+#   wait_for_downstream: false
+#   sla: !timedelta 'hours: 2'
+#   trigger_rule: all_success

--- a/examples/gusty_tutorial/print_date.yml
+++ b/examples/gusty_tutorial/print_date.yml
@@ -1,0 +1,2 @@
+operator: BashOperator
+bash_command: date

--- a/examples/gusty_tutorial/sleep.yml
+++ b/examples/gusty_tutorial/sleep.yml
@@ -1,0 +1,5 @@
+operator: BashOperator
+bash_command: sleep 5
+retries: 3
+dependencies:
+    - print_date

--- a/examples/gusty_tutorial/templated.yml
+++ b/examples/gusty_tutorial/templated.yml
@@ -1,0 +1,11 @@
+operator: BashOperator
+bash_command: |-
+    {% for i in range(5) %}
+        echo "{{ ds }}"
+        echo "{{ macros.ds_add(ds, 7)}}"
+        echo "{{ params.my_param }}"
+    {% endfor %}
+params:
+    my_param: Parameter I passed in
+dependencies:
+    - print_date

--- a/gusty/utils.py
+++ b/gusty/utils.py
@@ -1,0 +1,42 @@
+import yaml
+from datetime import datetime, timedelta
+
+from airflow.utils.dates import days_ago
+
+class GustyYAMLLoader(yaml.UnsafeLoader):
+    """
+    Loader used for loading DAG metadata. Has several custom
+    tags that support common Airflow metadata operations, such as
+    days_ago, timedelta, and datetime.
+    
+    Note that this is an UnsafeLoader, so it can execute arbitrary code.
+    Never run it on an untrusted YAML file (it is intended to be run
+    on YAML files representing Gusty operators or metadata).
+    """
+    def __init__(self, *args, **kwargs):
+        """Initialize the UnsafeLoader"""
+        super(GustyYAMLLoader, self).__init__(*args, **kwargs)
+        dag_yaml_tags = {'!days_ago': days_ago,
+                         '!timedelta': timedelta,
+                         '!datetime': datetime}
+
+        for tag, func in dag_yaml_tags.items():
+            self.add_constructor(tag, self.wrap_yaml(func))
+        
+        # Note that you could still apply any function with e.g.
+        # !!python/object/apply:datetime.timedelta [1]
+
+    def wrap_yaml(self, func):
+        """Turn a function into one that can be run on a YAML input"""
+        def ret(loader, x):
+            value = yaml.load(x.value, yaml.UnsafeLoader)
+    
+            if isinstance(value, list):
+                return func(*value)
+    
+            if isinstance(value, dict):
+                return func(**value)
+    
+            return func(value)
+    
+        return ret


### PR DESCRIPTION
Introduces the gusty.GustyDAG class, which initializes a DAG based on a folder. The folder may contain a METADATA.yml file that specifies arguments to the DAG, such as schedule_interval or default_args. This would simplify each DAG .py file (could be just a couple lines of code) and move a lot of the logic to the folder.

Also introduces two other things:

* GustyYAMLLoader is a YAML loader with a few helpful Airflow-specific functions. For example, in a YAML file you can represent days_ago with `start_date: !days_ago 1`. Especially helpful for the metadata loading, but I've changed the operator parsing to use this as well.

* examples/gusty_tutorial, which copies the default Airflow tutorial in the Gusty style.

You could test this by creating a DAG in two lines from the `gusty_tutorial` example:

```
from gusty import GustyDAG
dag = GustyDAG("examples/gusty_tutorial")
```

The result is a GustyDAG (which inherits airflow.DAG), and you can see that the DAG is configured based on the METADATA.yml file.

```
print(dag)
# <DAG: tutorial_example>
print(dag.description)
# A Gusty version of the DAG described by this Airflow tutorial: https://airflow.apache.org/docs/stable/tutorial.html
print(dag.schedule_interval)
# 1 0 * * *
print(dag.tasks)
# [<Task(BashOperator): print_date>, <Task(BashOperator): sleep>, <Task(BashOperator):templated>, <Task(LatestOnlyOperator): latest_only>]
```

This is a flexible pattern that could keep being extended in the future; often the same default arguments will be shared across many DAGs in Airflow, so one could imagine introducing something like a default METADATA.yml in the dags folder that applies to all DAGs within it. This can help reduce the per-DAG overhead.