### PR TITLE
Tasks override

### DIFF
--- a/gusty/__init__.py
+++ b/gusty/__init__.py
@@ -242,7 +242,6 @@ def build_tasks(yaml_specs, dag):
             if not hasattr(operator, 'template_fields')
                 or k in operator.template_fields
                 or k in inspect.signature(airflow.models.BaseOperator.__init__).parameters.keys()
-                or k in inspect.signature(airflow.DAG.__init__).parameters.keys()
                 }
         args["task_id"] = spec["task_id"]
         args["dag"] = dag

--- a/gusty/__init__.py
+++ b/gusty/__init__.py
@@ -4,6 +4,7 @@ import os
 import yaml
 import pkgutil
 import itertools
+import inspect
 
 import airflow
 airflow_version = int(str(airflow.__version__)[0])
@@ -239,7 +240,10 @@ def build_tasks(yaml_specs, dag):
         # The spec will have dag added and some keys removed
         args = {k:v for k,v in spec.items()
             if not hasattr(operator, 'template_fields')
-                or k in operator.template_fields}
+                or k in operator.template_fields
+                or k in inspect.signature(airflow.models.BaseOperator.__init__).parameters.keys()
+                or k in inspect.signature(airflow.DAG.__init__).parameters.keys()
+                }
         args["task_id"] = spec["task_id"]
         args["dag"] = dag
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gusty",
-    version="0.2.0",
+    version="0.2.1",
     author="Chris Cardillo",
     author_email="cfcardillo23@gmail.com",
     description="An opinionated framework for ETL built on top of Airflow",

--- a/tests/test_gustydag.py
+++ b/tests/test_gustydag.py
@@ -12,3 +12,6 @@ def test_dag_tasks(gustydag):
 
 def test_dag_task_dependencies(gustydag):
     assert gustydag._task_group.children['sleep']._upstream_task_ids == {'print_date'}
+
+def test_dag_task_dependencies(gustydag):
+    assert gustydag._task_group.children['sleep'].retries == 3


### PR DESCRIPTION
gusty should (and now does) accept any BaseOperator arguments (e.g. retries) that should (and now do) override DAG default args