### PR TITLE
Leaf tasks

### DIFF
--- a/gusty/__init__.py
+++ b/gusty/__init__.py
@@ -39,5 +39,6 @@ def create_dag(
     [setup.create_task_dependencies(level) for level in setup.levels]
     [setup.create_task_external_dependencies(level) for level in setup.levels]
     [setup.create_level_external_dependencies(level) for level in setup.levels]
+    [setup.create_leaf_tasks(level) for level in setup.levels]
     [setup.create_root_dependencies(level) for level in setup.levels]
     return setup.return_dag()

--- a/gusty/building.py
+++ b/gusty/building.py
@@ -747,7 +747,7 @@ class GustyBuilder:
                                 and name not in valid_leaf_tasks.keys()
                                 and name not in level_root_tasks
                             ):
-                                dependency.set_downstream(leaf_dep)
+                                leaf_dep.set_upstream(dependency)
 
     def return_dag(self):
         return get_top_level_dag(self.schematic)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gusty",
-    version="0.3.2",
+    version="0.3.3",
     author="Chris Cardillo",
     author_email="cfcardillo23@gmail.com",
     description="An opinionated framework for ETL built on top of Airflow",

--- a/tests/dags/with_metadata/METADATA.yml
+++ b/tests/dags/with_metadata/METADATA.yml
@@ -18,4 +18,6 @@ external_dependencies:
   - top_level_external: all
   - a_whole_dag: all
 root_tasks:
-  - root_sensor_task  
+  - root_sensor_task
+leaf_tasks:
+  - final_task

--- a/tests/dags/with_metadata/final_task.yml
+++ b/tests/dags/with_metadata/final_task.yml
@@ -1,0 +1,2 @@
+operator: airflow.operators.bash.BashOperator
+bash_command: echo final

--- a/tests/test_adjusted_behavior.py
+++ b/tests/test_adjusted_behavior.py
@@ -109,3 +109,10 @@ def test_root_dependency(dag):
     root_dict = [dep.__dict__["task_id"] for dep in dag.roots]
     root_sensor_task = dag.task_dict["root_sensor_task"]
     assert len(root_sensor_task.__dict__["_downstream_task_ids"]) > 0
+
+
+def test_leaf_tasks(dag):
+    assert len(dag.leaves) == 1
+    leaf_task = dag.leaves[0].__dict__
+    assert len(leaf_task["_downstream_task_ids"]) == 0
+    assert leaf_task["task_id"] == "final_task"


### PR DESCRIPTION
`leaf_tasks` is a list of task ids that can be passed to `create_dag` or a DAG's `METADATA.yml` that explicitly sets those tasks at the end of the DAG. It is the opposite of `root_tasks`.