### PR TITLE
a better ignore_subfolders and no need for template_fields

### DIFF
--- a/gusty/__init__.py
+++ b/gusty/__init__.py
@@ -32,6 +32,7 @@ def create_dag(
         **kwargs
     )
     [setup.parse_metadata(level) for level in setup.levels]
+    [setup.check_metadata(level) for level in setup.levels]
     [setup.create_structure(level) for level in setup.levels]
     [setup.read_specs(level) for level in setup.levels]
     [setup.create_tasks(level) for level in setup.levels]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gusty",
-    version="0.3.3",
+    version="0.3.4",
     author="Chris Cardillo",
     author_email="cfcardillo23@gmail.com",
     description="An opinionated framework for ETL built on top of Airflow",

--- a/tests/dags/ignore_subfolders/ignore_skiplevel/ignore_further/ignore_this_too.yml
+++ b/tests/dags/ignore_subfolders/ignore_skiplevel/ignore_further/ignore_this_too.yml
@@ -1,0 +1,2 @@
+operator: airflow.operators.bash.BashOperator
+bash_command: echo ignore

--- a/tests/test_ignore_subfolders.py
+++ b/tests/test_ignore_subfolders.py
@@ -52,3 +52,7 @@ def dag(no_metadata_dir):
 
 def test_ignore_subfolders(dag):
     assert "ignore_this_task" not in dag.task_dict.keys()
+
+
+def test_ignore_skiplevel(dag):
+    assert "ignore_this_too" not in dag.task_dict.keys()


### PR DESCRIPTION
`ignore_subfolders` is now much more intentional in how it removes sub-levels from a schematic.

In previous releases, in the internals, `template_fields` was used as a way to understand which fields in a YAML spec gusty should accept for a given operator, however since moving to `inspect.signature(operator.__init__)` a few release ago, `template_fields` has become an irrelevant way to determine what fields are accepted by an operator, and has now been removed.