### PR TITLE
new .py file interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ gusty will turn every file in a DAG directory into a task. gusty supports four d
 | File Type | How It Works                                                                                                   |
 | --------- | -------------------------------------------------------------------------------------------------------------- |
 | .yml      | Declare an `operator` and pass in any operator parameters using YAML                                           |
-| .py       | Simply define a function named `python_callable` and gusty will automatically turn it into a `PythonOperator`  |
+| .py       | Simply write Python code and by default gusty will execute your file using a `PythonOperator`                  |
 | .ipynb    | Put a YAML block at the top of your notebook and specify an `operator` that renders your Jupyter Notebook      |
 | .Rmd      | Use the YAML block at the top of your notebook and specify an `operator` that renders your R Markdown Document |
 
@@ -34,12 +34,11 @@ bash_command: echo hello world
 
 The resulting task would be a `BashOperator` with the task id `hello_world`.
 
-Here is the same approach using a Python file instead, named `hello_world.py`, which gusty will automatically turn into a `PythonOperator`:
+Here is the same approach using a Python file instead, named `hello_world.py`, which gusty will automatically turn into a `PythonOperator` by default:
 
 ```py
-def python_callable():
-  phrase = "hello world"
-  print(phrase)
+phrase = "hello world"
+print(phrase)
 ```
 
 ### Easy Dependencies
@@ -62,20 +61,27 @@ external_dependencies:
 
 For external dependencies, the keyword `all` can be used when the task should wait on an entire external DAG to run successfully.
 
-For a .py task file type, we can define these dependencies simply as variables:
+For a .py task file type, we can define these dependencies with some raw markdown at the top of the file:
 
 ```py
-dependencies = [
-  "same_dag_task"
-]
-external_dependencies = [
-  {"another_dag": "another_task"},
-  {"a_whole_dag": "all"}
-]
-def python_callable():
+# ---
+# dependencies:
+#   - same_dag_task
+# external_dependencies:
+#   - another_dag: another_task
+#   - a_whole_dag: all
+# python_callable: say_hello
+# ---
+
+def say_hello():
   phrase = "hello world"
   print(phrase)
 ```
+
+You will also note that we wrapped our previous Python code in a function called `say_hello`, and passed this function's name to the `python_callable` argument. By default, with no `operator` and no `python_callable` specified, gusty will pass a simple function that runs your .py file to the `PythonOperator`. If you pass an explicit `python_callable` by name, gusty will search your .py for that function and pass that function to the `PythonOperator` instead.
+
+.py files are capable of accepting an `operator` parameter in the raw markdown, just like any other task file type, which means you can use any other relevant operators (e.g. the `PythonVirtualenvOperator`) to execute your Python code as needed.
+
 
 #### Dynamic Dependencies
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,7 @@ jupyter-client==6.1.7
 jupyter-console==6.2.0
 jupyter-core==4.7.0
 jupyterlab-pygments==0.1.2
+jupytext==1.9.1
 lazy-object-proxy==1.4.3
 lockfile==0.12.2
 lxml==4.6.2

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gusty",
-    version="0.4.0",
+    version="0.5.0",
     author="Chris Cardillo",
     author_email="cfcardillo23@gmail.com",
-    description="An opinionated framework for ETL built on top of Airflow",
+    description="Making DAG construction easier",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/chriscardillo/gusty",
@@ -16,6 +16,7 @@ setuptools.setup(
     install_requires=[
           'apache-airflow',
           'inflection',
+          'jupytext',
           'nbformat',
           'python-frontmatter'
     ],

--- a/tests/dags/pydag/py_but_dummy.py
+++ b/tests/dags/pydag/py_but_dummy.py
@@ -1,0 +1,5 @@
+# ---
+# operator: airflow.operators.dummy.DummyOperator
+# python_callable: this does not run
+# ---
+print("another one")

--- a/tests/dags/pydag/py_task.py
+++ b/tests/dags/pydag/py_task.py
@@ -1,11 +1,14 @@
-dependencies = ["direct_dep"]
+# ---
+# email: new_email@gusty.com
+# dependencies:
+#   - direct_dep
+# external_dependencies:
+#   - a_whole_dag: all
+# python_callable: hello_world
+# ---
 
-external_dependencies = [{"a_whole_dag": "all"}]
 
-email = "new_email@gusty.com"
-
-
-def python_callable():
+def hello_world():
     phrase = "hello python task"
     print(phrase)
     return phrase

--- a/tests/dags/pydag/simple_leaf.py
+++ b/tests/dags/pydag/simple_leaf.py
@@ -1,2 +1,3 @@
-def python_callable():
-    pass
+# This ain't nothin' but a comment, I hope.
+
+print("I am a simple leaf")

--- a/tests/test_python_tasks.py
+++ b/tests/test_python_tasks.py
@@ -1,5 +1,6 @@
 import pytest
 from gusty import create_dag
+from airflow.operators.dummy import DummyOperator
 
 ###############
 ## FIXTURES ##
@@ -54,3 +55,17 @@ def test_py_task_external_dependencies(py_task):
 def test_py_task_dependencies(py_task):
     assert "direct_dep" in py_task.__dict__["_upstream_task_ids"]
     assert "simple_leaf" in py_task.__dict__["_downstream_task_ids"]
+
+
+def test_py_dummy(dag):
+    """
+    This really tests to ensure that in theory the contents of the .py could
+    be run by other operators as needed.
+    """
+    task = dag.task_dict["py_but_dummy"]
+    assert isinstance(task, DummyOperator)
+
+
+def test_automatic_py(dag, py_task):
+    task = dag.task_dict["simple_leaf"]
+    assert type(py_task) == type(task)


### PR DESCRIPTION
Dropped requirement for `python_callable` in .py task files. gusty will just pass a lambda of `exec(open(file).read())` to `PythonOperator` by default.

Arguments such as `dependencies` are now passed raw markdown at the beginning of the .py task files instead of variables in the file. This will allow for users to pass in their other operators as they see fit.