### PR TITLE
[WIP] fix inspect signature to not assume __init__ meth

### DIFF
--- a/gusty/building.py
+++ b/gusty/building.py
@@ -99,8 +99,8 @@ def build_task(spec, level_id, schematic):
         k: v
         for k, v in spec.items()
         if k
-        in inspect.signature(airflow.models.BaseOperator.__init__).parameters.keys()
-        or k in inspect.signature(operator.__init__).parameters.keys()
+        in inspect.signature(airflow.models.BaseOperator).parameters.keys()
+        or k in inspect.signature(operator).parameters.keys()
     }
     args["task_id"] = spec["task_id"]
     args["dag"] = get_top_level_dag(schematic)

--- a/gusty/building.py
+++ b/gusty/building.py
@@ -104,7 +104,7 @@ def build_task(spec, level_id, schematic):
     args = {
         k: v
         for k, v in spec.items()
-        if k 
+        if k
         in inspect.signature(airflow.models.BaseOperator.__init__).parameters.keys()
         or k in _get_operator_parameters(operator)
     }

--- a/gusty/building.py
+++ b/gusty/building.py
@@ -88,6 +88,12 @@ def parse_external_dependencies(external_dependencies):
 ## Builder Functions ##
 #######################
 
+def _get_operator_parameters(operator):
+    params = getattr(operator, "_gusty_parameters", None)
+    if params is not None:
+        return params
+
+    return inspect.signature(operator.__init__).parameters.keys()
 
 def build_task(spec, level_id, schematic):
     """
@@ -98,9 +104,9 @@ def build_task(spec, level_id, schematic):
     args = {
         k: v
         for k, v in spec.items()
-        if k
-        in inspect.signature(airflow.models.BaseOperator).parameters.keys()
-        or k in inspect.signature(operator).parameters.keys()
+        if k 
+        in inspect.signature(airflow.models.BaseOperator.__init__).parameters.keys()
+        or k in _get_operator_parameters(operator)
     }
     args["task_id"] = spec["task_id"]
     args["dag"] = get_top_level_dag(schematic)

--- a/tests/test_custom_operators.py
+++ b/tests/test_custom_operators.py
@@ -1,0 +1,34 @@
+from airflow.models.baseoperator import BaseOperator
+from gusty.building import _get_operator_parameters
+
+
+def test_get_operator_parameters():
+
+    class ACustomOperator(BaseOperator):
+        def __init__(self, a, **kwargs):
+            self.a = 1
+    
+            super().__init__(**kwargs)
+    
+        def execute(self, context):
+            print(self.a)
+
+    params = _get_operator_parameters(ACustomOperator)
+
+    assert "a" in params
+    assert list(params) == ["self", "a", "kwargs"]
+
+
+def test_get_operator_parameters_attribute():
+    f = lambda a, **kwargs: BaseOperator(**kwargs)
+    f._gusty_parameters = ("a",)
+
+    params = _get_operator_parameters(f)
+
+    assert "a" in params
+    assert list(params) == ["a"]
+
+
+
+
+


### PR DESCRIPTION
@chriscardillo this PR should support all current behavior, and partially addresses #26, by allowing gusty to read signatures that operator constructors might use:

* constructor is a class initialized by `__init__` method (current case)
* constructor is a function (more precisely, a callable)
* constructor is class initialized by `__new__` method

This does not address the use of `*args` and `**kwargs`, but should allow people to create op instances using some common python approaches:

```python
class MyOperator:
    def __init__(self, a, b):
        self.a = a
        self.b = b

# approach 1: directly call class ----
MyOperator('x', 'y')

# approach 2 ----
def make_operator(b):
    return MyOperator('x', b)

# similarly.. with a partial func
from functools import partial
import inspect

make_operator2 = partial(MyOperator, 'x')
make_operator2('y')

inspect.signature(pf).parameters.keys()     # odict_keys(['b'])
```

Here's a code snippet showing how the change operates on different class setups!:

```python
from inspect import signature

class A:
    # should be ignored, since is used when calling a class *instance*
    def __call__(self, c):
        pass    
    
class B(A):
    # the classic signature
    def __init__(self, b, c, *args, **kwargs):
        pass
    
class C(B):
    # will be called instead of __init__, so this is the signature now
    def __new__(cls, a, b, c, *args, **kwargs):
        return cls(a)

signature(A)     # <Signature ()>
signature(B)     # <Signature (b, c, *args, **kwargs)>
signature(C)     # <Signature (a, b, c, *args, **kwargs)>
```


