### PR TITLE
V0.5.5

### DIFF
--- a/gusty/building.py
+++ b/gusty/building.py
@@ -88,12 +88,14 @@ def parse_external_dependencies(external_dependencies):
 ## Builder Functions ##
 #######################
 
+
 def _get_operator_parameters(operator):
     params = getattr(operator, "_gusty_parameters", None)
     if params is not None:
         return params
 
     return inspect.signature(operator.__init__).parameters.keys()
+
 
 def build_task(spec, level_id, schematic):
     """

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="gusty",
     version="0.5.5",
-    author="Chris Cardillo",
+    author="Chris Cardillo, Michael Chow, David Robinson",
     author_email="cfcardillo23@gmail.com",
     description="Making DAG construction easier",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gusty",
-    version="0.5.4",
+    version="0.5.5",
     author="Chris Cardillo",
     author_email="cfcardillo23@gmail.com",
     description="Making DAG construction easier",

--- a/tests/dags/pydag/py_but_dummy.py
+++ b/tests/dags/pydag/py_but_dummy.py
@@ -1,5 +1,4 @@
 # ---
 # operator: airflow.operators.dummy.DummyOperator
-# python_callable: this does not run
 # ---
 print("another one")

--- a/tests/test_custom_operators.py
+++ b/tests/test_custom_operators.py
@@ -3,13 +3,12 @@ from gusty.building import _get_operator_parameters
 
 
 def test_get_operator_parameters():
-
     class ACustomOperator(BaseOperator):
         def __init__(self, a, **kwargs):
             self.a = 1
-    
+
             super().__init__(**kwargs)
-    
+
         def execute(self, context):
             print(self.a)
 
@@ -27,8 +26,3 @@ def test_get_operator_parameters_attribute():
 
     assert "a" in params
     assert list(params) == ["a"]
-
-
-
-
-


### PR DESCRIPTION
- `python_callable` available much more freely across any customer operator.
- `_gusty_parameters` is available to override the inspecting of the `__init__` signature of custom operators.