### PR TITLE
v0.6.1

### DIFF
--- a/gusty/building.py
+++ b/gusty/building.py
@@ -1,5 +1,6 @@
 import os, yaml, inspect, airflow
 from airflow import DAG
+from gusty.errors import NonexistentDagDirError
 from gusty.parsing import parse, default_parsers
 from gusty.parsing.loaders import GustyYAMLLoader
 from gusty.importing import airflow_version, get_operator
@@ -185,6 +186,11 @@ class GustyBuilder:
         "structure" (DAG or TaskGroup), tasks, dependencies, and external_dependencies, so on,
         until the DAG is complete.
         """
+
+        if not os.path.isdir(dag_dir):
+            raise NonexistentDagDirError(
+                "DAG directory {dag_dir} does not exist".format(dag_dir=dag_dir)
+            )
 
         self.parsers = default_parsers.copy()
 

--- a/gusty/errors.py
+++ b/gusty/errors.py
@@ -1,0 +1,2 @@
+class NonexistentDagDirError(Exception):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gusty",
-    version="0.6.0",
+    version="0.6.1",
     author="Chris Cardillo, Michael Chow, David Robinson",
     author_email="cfcardillo23@gmail.com",
     description="Making DAG construction easier",

--- a/tests/test_no_dir.py
+++ b/tests/test_no_dir.py
@@ -1,0 +1,29 @@
+import pytest
+from gusty import create_dag
+from gusty.errors import NonexistentDagDirError
+
+##############
+## FIXTURES ##
+##############
+
+
+@pytest.fixture(scope="session")
+def nonexistent_dir():
+    return "tests/dagz/nonexistent"
+
+
+###########
+## TESTS ##
+###########
+
+
+def test_missing_dag_error(nonexistent_dir):
+    with pytest.raises(NonexistentDagDirError) as e:
+        create_dag(nonexistent_dir)
+
+
+def test_missing_dag_message(nonexistent_dir):
+    try:
+        create_dag(nonexistent_dir)
+    except NonexistentDagDirError as e:
+        assert str(e) == "DAG directory tests/dagz/nonexistent does not exist"


### PR DESCRIPTION
Added `NonexistentDagDirError` to give a clear error message when creating a DAG from a directory that does not exist.

fixes #30 