### PR TITLE
V0.8.0

### DIFF
--- a/gusty/building.py
+++ b/gusty/building.py
@@ -83,7 +83,14 @@ def parse_external_dependencies(external_dependencies):
     """
     Document
     """
-    deps = [j for i in external_dependencies for j in i.items()]
+    if isinstance(external_dependencies, dict):
+        deps = []
+        for dag_name, dag_details in external_dependencies.items():
+            for task_name in dag_details["tasks"]:
+                deps.append((dag_name, task_name))
+
+    else:
+        deps = [j for i in external_dependencies for j in i.items()]
     return deps
 
 
@@ -521,12 +528,8 @@ class GustyBuilder:
                 if spec["task_id"] == task_id and "external_dependencies" in spec.keys()
             }
             if len(task_spec_external_dependencies) > 0:
-                task_external_dependencies = [
-                    external_dependency
-                    for external_dependency in task_spec_external_dependencies[task_id]
-                ]
                 task_external_dependencies = parse_external_dependencies(
-                    task_external_dependencies
+                    task_spec_external_dependencies[task_id]
                 )
                 for dag_task_pair in task_external_dependencies:
                     external_dag_id, external_task_id = dag_task_pair

--- a/gusty/building.py
+++ b/gusty/building.py
@@ -83,7 +83,8 @@ def parse_external_dependencies(external_dependencies):
     """
     Document
     """
-    return dict(j for i in external_dependencies for j in i.items())
+    deps = [j for i in external_dependencies for j in i.items()]
+    return deps
 
 
 #######################
@@ -527,10 +528,8 @@ class GustyBuilder:
                 task_external_dependencies = parse_external_dependencies(
                     task_external_dependencies
                 )
-                for (
-                    external_dag_id,
-                    external_task_id,
-                ) in task_external_dependencies.items():
+                for dag_task_pair in task_external_dependencies:
+                    external_dag_id, external_task_id = dag_task_pair
                     wait_for_task_name = (
                         "wait_for_DAG_{x}".format(x=external_dag_id)
                         if external_task_id == "all"
@@ -564,10 +563,8 @@ class GustyBuilder:
                 level_external_dependencies = parse_external_dependencies(
                     level_external_dependencies
                 )
-                for (
-                    external_dag_id,
-                    external_task_id,
-                ) in level_external_dependencies.items():
+                for dag_task_pair in level_external_dependencies:
+                    external_dag_id, external_task_id = dag_task_pair
                     wait_for_task_name = (
                         "wait_for_DAG_{x}".format(x=external_dag_id)
                         if external_task_id == "all"
@@ -689,10 +686,8 @@ class GustyBuilder:
                 level_external_dependencies = parse_external_dependencies(
                     level_external_dependencies
                 )
-                for (
-                    external_dag_id,
-                    external_task_id,
-                ) in level_external_dependencies.items():
+                for dag_task_pair in level_external_dependencies:
+                    external_dag_id, external_task_id = dag_task_pair
                     wait_for_task_name = (
                         "wait_for_DAG_{x}".format(x=external_dag_id)
                         if external_task_id == "all"

--- a/gusty/parsing/__init__.py
+++ b/gusty/parsing/__init__.py
@@ -51,7 +51,7 @@ def parse(file_path, parse_dict=default_parsers, loader=None):
         )
         assert all(
             [isinstance(dep, str) for dep in yaml_file["dependencies"]]
-        ), "external_dependencies needs to be a list of strings in {file_path}".format(
+        ), "dependencies needs to be a list of strings in {file_path}".format(
             file_path=file_path
         )
     if "external_dependencies" in yaml_file.keys():

--- a/gusty/parsing/__init__.py
+++ b/gusty/parsing/__init__.py
@@ -54,16 +54,5 @@ def parse(file_path, parse_dict=default_parsers, loader=None):
         ), "dependencies needs to be a list of strings in {file_path}".format(
             file_path=file_path
         )
-    if "external_dependencies" in yaml_file.keys():
-        assert isinstance(
-            yaml_file["external_dependencies"], list
-        ), "external_dependencies needs to be a list of dicts in {file_path}".format(
-            file_path=file_path
-        )
-        assert all(
-            [isinstance(dep, dict) for dep in yaml_file["external_dependencies"]]
-        ), "external_dependencies needs to be a list of dicts in {file_path}".format(
-            file_path=file_path
-        )
 
     return yaml_file

--- a/setup.py
+++ b/setup.py
@@ -13,17 +13,11 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/chriscardillo/gusty",
     packages=setuptools.find_packages(),
-    install_requires=[
-          'apache-airflow',
-          'inflection',
-          'jupytext',
-          'nbformat',
-          'PyYaml'
-    ],
+    install_requires=["apache-airflow", "inflection", "jupytext", "nbformat", "PyYaml"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gusty",
-    version="0.7.2",
+    version="0.8.0",
     author="Chris Cardillo, Michael Chow, David Robinson",
     author_email="cfcardillo23@gmail.com",
     description="Making DAG construction easier",

--- a/tests/dags/external_deps/METADATA.yml
+++ b/tests/dags/external_deps/METADATA.yml
@@ -1,0 +1,16 @@
+description: "For testing dictionaries for external_dependencies"
+schedule_interval: "0 0 * * *"
+default_args:
+    owner: Meta Owner
+    depends_on_past: False
+    start_date: !days_ago 1
+    email: meta@gusty.com
+    email_on_failure: False
+    email_on_retry: False
+    retry_delay: !timedelta 'minutes: 5'
+    sla: !timedelta 'hours: 2'
+external_dependencies:
+  top_level_external:
+    execution_delta: !timedelta 'minutes: 88'
+    tasks:
+      - all

--- a/tests/dags/external_deps/a_group/METADATA.yml
+++ b/tests/dags/external_deps/a_group/METADATA.yml
@@ -1,0 +1,5 @@
+external_dependencies:
+  task_group_external:
+    execution_delta: !timedelta 'minutes: 89'
+    tasks:
+      - some_task

--- a/tests/dags/external_deps/a_group/another_task.yml
+++ b/tests/dags/external_deps/a_group/another_task.yml
@@ -1,0 +1,1 @@
+operator: airflow.operators.dummy.DummyOperator

--- a/tests/dags/external_deps/a_task.yml
+++ b/tests/dags/external_deps/a_task.yml
@@ -1,0 +1,8 @@
+operator: airflow.operators.dummy.DummyOperator
+external_dependencies:
+  task_level_external:
+    retries: 95
+    execution_delta: !timedelta 'minutes: 95'
+    tasks:
+      - another_task_1
+      - another_task_2

--- a/tests/dags/no_metadata/second_level/dependable_task.yml
+++ b/tests/dags/no_metadata/second_level/dependable_task.yml
@@ -2,3 +2,4 @@ operator: airflow.operators.dummy.DummyOperator
 external_dependencies:
   - a_whole_dag: all
   - external_dag: external_task
+  - external_dag: external_task_2

--- a/tests/dags/no_metadata/second_level/task_overrides_retries.yml
+++ b/tests/dags/no_metadata/second_level/task_overrides_retries.yml
@@ -3,4 +3,10 @@ retries: 100
 dependencies:
   - dependable_task
 external_dependencies:
-  - a_whole_dag: all
+  a_whole_dag:
+    tasks:
+      - all
+  another_dag:
+    tasks:
+      - another_task_1
+      - another_task_2

--- a/tests/test_default_behavior.py
+++ b/tests/test_default_behavior.py
@@ -100,6 +100,7 @@ def test_external_dependencies(dag):
     dependable_task_dependencies = dependable_task.__dict__["_upstream_task_ids"]
     assert "wait_for_DAG_a_whole_dag" in dependable_task_dependencies
     assert "wait_for_external_task" in dependable_task_dependencies
+    assert "wait_for_external_task_2" in dependable_task_dependencies
 
 
 def test_tasks_created(dag, dag_files):

--- a/tests/test_default_behavior.py
+++ b/tests/test_default_behavior.py
@@ -103,6 +103,16 @@ def test_external_dependencies(dag):
     assert "wait_for_external_task_2" in dependable_task_dependencies
 
 
+def test_external_dependencies_dict_tasks(dag):
+    ext_dep_dict_spec_task = dag.task_dict["task_overrides_retries"]
+    ext_dep_dict_spec_task_dependencies = ext_dep_dict_spec_task.__dict__[
+        "_upstream_task_ids"
+    ]
+    assert "wait_for_DAG_a_whole_dag" in ext_dep_dict_spec_task_dependencies
+    assert "wait_for_another_task_1" in ext_dep_dict_spec_task_dependencies
+    assert "wait_for_another_task_2" in ext_dep_dict_spec_task_dependencies
+
+
 def test_tasks_created(dag, dag_files):
     def replace_extension(file):
         final = None

--- a/tests/test_external_deps.py
+++ b/tests/test_external_deps.py
@@ -1,0 +1,44 @@
+import pytest
+from gusty import create_dag
+from datetime import timedelta
+
+###############
+## FIXTURES ##
+###############
+
+
+@pytest.fixture(scope="session")
+def external_deps_dir():
+    return "tests/dags/external_deps"
+
+
+@pytest.fixture(scope="session")
+def dag(external_deps_dir):
+    dag = create_dag(
+        external_deps_dir,
+        default_args={"email": "default@gusty.com", "retries": 5},
+        task_group_defaults={"prefix_group_id": True},
+        wait_for_defaults={"poke_interval": 12},
+    )
+    return dag
+
+
+###########
+## TESTS ##
+###########
+
+
+def test_dag_level_ext_dep(dag):
+    wait_for_task = dag.task_dict["wait_for_DAG_top_level_external"]
+    assert wait_for_task.__dict__["execution_delta"] == timedelta(minutes=88)
+
+
+def test_task_group_level_ext_dep(dag):
+    wait_for_task = dag.task_dict["wait_for_some_task"]
+    assert wait_for_task.__dict__["execution_delta"] == timedelta(minutes=89)
+
+
+def test_task_level_ext_dep(dag):
+    wait_for_task = dag.task_dict["wait_for_another_task_1"]
+    assert wait_for_task.__dict__["execution_delta"] == timedelta(minutes=95)
+    assert wait_for_task.__dict__["retries"] == 95


### PR DESCRIPTION
`external_dependencies` blocks now accept dicts, where the keys are the external DAG names and the values are either:

- `tasks`: A list of tasks out of which ExternalTaskSensors should be created
- ExternalTaskSensor parameters, such as `retries` or `execution_delta`, so that users can override any `wait_for_defaults` set on the DAG-level.

`external_dependencies` dicts are available at the task, task group, and DAG level.

Additionally, a bug was fixed, so now multiple tasks from one external DAG can be listed in `external_dependencies` blocks. Note that list-style `external_dependencies` are permissible.