### PR TITLE
v0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,48 @@ You might notice that `task_group_defaults` does not include dependencies. For T
 
 Default arguments in `create_dag` and a DAG or TaskGroup's `METADATA.yml` can be mixed and matched. `METADATA.yml` will always override defaults set in `create_dag`.
 
+#### create_dags
+
+If you have multiple gusty DAGs located inside of a single directory, you can conveniently use the `create_dags` (plural) function.
+
+`create_dags` works just like `create_dag`, with two exceptions:
+
+1. The first argument to `create_dags` is the path to a directory with many gusty DAGs.
+
+2. The second argument to `create_dags` is `globals()`. `gloabls()` is essentially the namespace to which your DAGs are assigned.
+
+Let's adjust the above `create_dag` example to use `create_dags` instead:
+
+```py
+import airflow
+from datetime import timedelta
+from airflow.utils.dates import days_ago
+from gusty import create_dags
+
+create_dags(
+  '/usr/local/airflow/my_gusty_dags',
+  globals(),
+  description="A default description for my DAGs.",
+  schedule_interval="1 0 * * *",
+  default_args={
+      "owner": "airflow",
+      "depends_on_past": False,
+      "start_date": days_ago(1),
+      "email": "airflow@example.com",
+      "email_on_failure": False,
+      "email_on_retry": False,
+      "retries": 1,
+      "retry_delay": timedelta(minutes=5),
+  },
+  task_group_defaults={
+      "tooltip": "This is a task group tooltip",
+      "prefix_group_id": True
+  }
+)
+```
+
+The above will create many gusty DAGs located in the `/usr/local/airflow/my_gusty_dags` directory.
+
 #### DAG-level Features
 
 gusty features additional helpful arguments at the DAG-level to help you design your DAGs with ease:

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ gusty will convert the above in two task instances, `python_task_1` and `python_
 
 One good thing about gusty is that if you choose to use this package, gusty doesn't have to be the **only** way that you create DAGs. You can use gusty's `create_dag` to generate DAGs out of directories where applicable, and then implement more traditional methods of creating Airflow DAGs where the tried and true methods feel like a better approach.
 
-So feel free to give the gusty approach a try, because you don't have to commit to it everywhere. But when you try it, don't be surprised if you are blown away.
+So feel free to give the gusty approach a try, because you don't have to commit to it everywhere. But when you try it, don't be surprised if you start using it everywhere!
 
 ## Containerized Demo
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ gusty features additional helpful arguments at the DAG-level to help you design 
   - **`leaf_tasks`** - A list of task ids which should represent the leaves of a DAG. For example, at the end of the DAG run, you might save a report to S3.
   - **`external_dependencies`** - You can also set external dependencies at the DAG level! Making your DAG wait on other DAGs works just like in the external dependencies examples above.
   - **`ignore_subfolders`** - If you don't want subfolders to generate Task Groups, set this to `True`.
-  - **`latest_only`** - On by default, installs a `LatestOnlyOperator` at the absolute root of the DAG, skipping all tasks in the DAG if the DAG run is not the current run. You can read more about the LatestOnlyOperator in [Airflow's documentation](https://airflow.apache.org/docs/apache-airflow/stable/concepts.html#latest-run-only).
+  - **`latest_only`** - On by default, installs a `LatestOnlyOperator` at the absolute root of the DAG, skipping all tasks in the DAG if the DAG run is not the current run. You can read more about the LatestOnlyOperator in [Airflow's documentation](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/operators/latest_only/index.html?highlight=latestonly#airflow.operators.latest_only.LatestOnlyOperator).
 
   Any of these arguments can be placed in `create_dag` or `METADATA.yml`!
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ If you have multiple gusty DAGs located inside of a single directory, you can co
 
 1. The first argument to `create_dags` is the path to a directory with many gusty DAGs.
 
-2. The second argument to `create_dags` is `globals()`. `gloabls()` is essentially the namespace to which your DAGs are assigned.
+2. The second argument to `create_dags` is `globals()`. `globals()` is essentially the namespace to which your DAGs are assigned.
 
 Let's adjust the above `create_dag` example to use `create_dags` instead:
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ from gusty import create_dag
 
 dag = create_dag(
   '/usr/local/airflow/dags/hello_world',
-  description="A dag created without any metadata",
+  description="A DAG created without any metadata",
   schedule_interval="1 0 * * *",
   default_args={
       "owner": "airflow",

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
-ABSQL==0.2.1
-apache-airflow==2.3.3
+ABSQL==0.2.2
+apache-airflow==2.3.4
 inflection==0.5.1
-jupytext==1.14.0
+jupytext==1.14.1
 nbformat==5.4.0
 PyYAML==6.0

--- a/gusty/__init__.py
+++ b/gusty/__init__.py
@@ -65,4 +65,5 @@ def create_dag(
     [setup.create_root_dependencies(level) for level in setup.levels]
     return setup.return_dag()
 
-from gusty.multi import create_dags
+
+from gusty.multi import create_dags  # noqa

--- a/gusty/parsing/__init__.py
+++ b/gusty/parsing/__init__.py
@@ -82,7 +82,7 @@ def parse(file_path, parse_dict=default_parsers, loader=None, runner=None):
         for task_id, spec in multi_task_spec.items():
             base_spec = yaml_file.copy()
             base_spec["task_id"] = task_id
-            base_spec = nested_update(base_spec, spec)
+            nested_update(base_spec, spec)
             multi_specs.append(base_spec)
 
     if len(multi_specs) > 0:

--- a/gusty/parsing/__init__.py
+++ b/gusty/parsing/__init__.py
@@ -4,6 +4,7 @@ from functools import partial
 from absql.utils import get_function_arg_names
 from gusty.parsing.loaders import generate_loader
 from gusty.parsing.parsers import parse_generic, parse_py, parse_ipynb, parse_sql
+from gusty.utils import nested_update
 
 default_parsers = {
     ".yml": parse_generic,
@@ -81,7 +82,7 @@ def parse(file_path, parse_dict=default_parsers, loader=None, runner=None):
         for task_id, spec in multi_task_spec.items():
             base_spec = yaml_file.copy()
             base_spec["task_id"] = task_id
-            base_spec.update(spec)
+            base_spec = nested_update(base_spec, spec)
             multi_specs.append(base_spec)
 
     if len(multi_specs) > 0:

--- a/gusty/utils.py
+++ b/gusty/utils.py
@@ -1,3 +1,4 @@
+import collections.abc
 from pendulum import today
 
 
@@ -5,3 +6,12 @@ def days_ago(n):
     """Get a datetime object representing n days ago."""
     n = -1 * n
     return today("UTC").add(days=n)
+
+
+def nested_update(d, u):
+    for k, v in u.items():
+        if isinstance(v, collections.abc.Mapping):
+            d[k] = nested_update(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gusty",
-    version="0.12.0",
+    version="0.12.1",
     author="Chris Cardillo, Michael Chow, David Robinson",
     author_email="cfcardillo23@gmail.com",
     description="Making DAG construction easier",

--- a/tests/dags/multi_task/nested_python.py
+++ b/tests/dags/multi_task/nested_python.py
@@ -1,0 +1,15 @@
+# ---
+# python_callable: main
+# op_kwargs:
+#   foo: bar
+#   min: max
+# multi_task_spec:
+#   nested_py:
+#       op_kwargs:
+#           biz: bazz
+#           min: mouse
+# ---
+
+
+def main(foo, biz, min):
+    return foo + biz

--- a/tests/dags/multi_task/nested_python.py
+++ b/tests/dags/multi_task/nested_python.py
@@ -19,5 +19,14 @@
 # ---
 
 
-def main(foo, biz, min):
-    return foo + biz
+def main(foo, biz, min, outer_dict, inner_dict, updated_dict):
+    return ", ".join(
+        [
+            foo,
+            biz,
+            min,
+            outer_dict["outer"],
+            inner_dict["inner"],
+            updated_dict["updated"],
+        ]
+    )

--- a/tests/dags/multi_task/nested_python.py
+++ b/tests/dags/multi_task/nested_python.py
@@ -3,11 +3,19 @@
 # op_kwargs:
 #   foo: bar
 #   min: max
+#   outer_dict:
+#       outer: dict
+#   updated_dict:
+#       updated: dict
 # multi_task_spec:
 #   nested_py:
 #       op_kwargs:
 #           biz: bazz
 #           min: mouse
+#           inner_dict:
+#               inner: dict
+#           updated_dict:
+#               updated: updated
 # ---
 
 

--- a/tests/test_multi_task.py
+++ b/tests/test_multi_task.py
@@ -89,3 +89,9 @@ def test_nested_update(dag):
     assert op_kwargs["outer_dict"] == {"outer": "dict"}
     assert op_kwargs["inner_dict"] == {"inner": "dict"}
     assert op_kwargs["updated_dict"] == {"updated": "updated"}
+
+
+def test_nested_result(dag):
+    op_kwargs = dag.task_dict["nested_py"].__dict__["op_kwargs"]
+    callable = dag.task_dict["nested_py"].__dict__["python_callable"]
+    assert callable(**op_kwargs) == "bar, bazz, mouse, dict, dict, updated"

--- a/tests/test_multi_task.py
+++ b/tests/test_multi_task.py
@@ -86,3 +86,6 @@ def test_nested_update(dag):
     assert op_kwargs["foo"] == "bar"
     assert op_kwargs["biz"] == "bazz"
     assert op_kwargs["min"] == "mouse"
+    assert op_kwargs["outer_dict"] == {"outer": "dict"}
+    assert op_kwargs["inner_dict"] == {"inner": "dict"}
+    assert op_kwargs["updated_dict"] == {"updated": "updated"}

--- a/tests/test_multi_task.py
+++ b/tests/test_multi_task.py
@@ -78,4 +78,11 @@ def test_combined_multi_partials(dag):
 
 
 def test_correct_task_count(dag):
-    assert len(dag.task_dict) == 5
+    assert len(dag.task_dict) == 6
+
+
+def test_nested_update(dag):
+    op_kwargs = dag.task_dict["nested_py"].__dict__["op_kwargs"]
+    assert op_kwargs["foo"] == "bar"
+    assert op_kwargs["biz"] == "bazz"
+    assert op_kwargs["min"] == "mouse"


### PR DESCRIPTION
- `multi_task_spec` can now update its base spec collections. This means top-level dictionaries in a spec can be partially or completely updated with their equivalent dictionaries in `multi_task_spec`.

- Updated README to include instructions on how to use `create_dags`

- Updated `dev-requirements.txt`