### PR TITLE
Prune `airflow` imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ While `METADATA.yml` will always be the primary source of truth for a DAG or Tas
 Here's an example using `create_dag`, where instead of metadata we use `create_dag` arguments:
 
 ```py
-import airflow
 from datetime import timedelta
 from airflow.utils.dates import days_ago
 from gusty import create_dag
@@ -192,7 +191,6 @@ If you have multiple gusty DAGs located inside of a single directory, you can co
 Let's adjust the above `create_dag` example to use `create_dags` instead:
 
 ```py
-import airflow
 from datetime import timedelta
 from airflow.utils.dates import days_ago
 from gusty import create_dags

--- a/gusty/__init__.py
+++ b/gusty/__init__.py
@@ -1,4 +1,3 @@
-import airflow  # noqa
 from gusty.building import GustyBuilder
 
 

--- a/gusty/building.py
+++ b/gusty/building.py
@@ -1,5 +1,5 @@
-import os, inspect, airflow
-from airflow import DAG
+import os, inspect
+from airflow.models import BaseOperator, DAG
 from absql import Runner
 from functools import partial
 from gusty.errors import NonexistentDagDirError
@@ -150,7 +150,7 @@ def build_task(spec, level_id, schematic):
         k: v
         for k, v in spec.items()
         if k
-        in inspect.signature(airflow.models.BaseOperator.__init__).parameters.keys()
+        in inspect.signature(BaseOperator.__init__).parameters.keys()
         or k in _get_operator_parameters(operator)
         or k in _get_operator_parameters(operator.__base__)
     }
@@ -289,7 +289,7 @@ class GustyBuilder:
                 if k in AVAILABLE_WAIT_FOR_PARAMS
                 or k
                 in inspect.signature(
-                    airflow.models.BaseOperator.__init__
+                    BaseOperator.__init__
                 ).parameters.keys()
             }
             self.wait_for_defaults.update(user_wait_for_defaults)

--- a/gusty/importing.py
+++ b/gusty/importing.py
@@ -1,11 +1,12 @@
-import os, sys, pkgutil, itertools, airflow, importlib
+import os, sys, pkgutil, itertools, importlib
+from airflow.version import version as _airflow_version
 from inflection import underscore
 
 ############
 ## Params ##
 ############
 
-airflow_version = int(str(airflow.__version__).split(".")[0])
+airflow_version = int(_airflow_version.split(".")[0])
 
 ###########################
 ## Operator Import Logic ##


### PR DESCRIPTION
Behind the scenes, Airflow checks for files to be parsed for DAGs (and even ones that might be used to dynamically create DAGs) by [literally searching file contents for "airflow" or "dag"](https://github.com/apache/airflow/blob/c4e10ac9e70a27c8871f2c03705065397c78ebf1/airflow/utils/file.py#L358) and attempts to then execute said code to build the DAG objects. You don't necessarily have to import `airflow` but rather have those keywords _somewhere_.

Either removing or making `airflow` imports more targeted in hopes to improve import performance at parse-time.