### PR TITLE
V0.18.1

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,5 +2,7 @@ ABSQL==0.4.0
 apache-airflow==2.5.2
 inflection==0.5.1
 jupytext==1.14.5
+line-profiler==4.0.3
 nbformat==5.7.3
 PyYAML==6.0
+snakeviz==2.1.1

--- a/gusty/building.py
+++ b/gusty/building.py
@@ -133,13 +133,22 @@ def parse_wait_for_overrides(external_dependencies):
 ## Builder Functions ##
 #######################
 
+OPERATOR_PARAM_CACHE = {}
+
 
 def _get_operator_parameters(operator):
-    params = getattr(operator, "_gusty_parameters", None)
-    if params is not None:
+    params = OPERATOR_PARAM_CACHE.get(operator)
+    if params:
         return params
 
-    return inspect.signature(operator.__init__).parameters.keys()
+    params = getattr(operator, "_gusty_parameters", None)
+    if params is not None:
+        OPERATOR_PARAM_CACHE.update({operator: params})
+        return params
+
+    params = inspect.signature(operator.__init__).parameters.keys()
+    OPERATOR_PARAM_CACHE.update({operator: params})
+    return params
 
 
 def build_task(spec, level_id, schematic):

--- a/gusty/building.py
+++ b/gusty/building.py
@@ -25,9 +25,9 @@ if airflow_version > 1:
 else:
     from airflow.operators.latest_only_operator import LatestOnlyOperator
 
-#####################
-## Wait for Params ##
-#####################
+###############
+## Constants ##
+###############
 
 AVAILABLE_WAIT_FOR_PARAMS = [
     "poke_interval",
@@ -39,6 +39,8 @@ AVAILABLE_WAIT_FOR_PARAMS = [
     "execution_date_fn",
     "check_existence",
 ]
+
+BASE_OPERATOR_KEYS = inspect.signature(BaseOperator.__init__).parameters.keys()
 
 #########################
 ## Schematic Functions ##
@@ -150,7 +152,7 @@ def build_task(spec, level_id, schematic):
     args = {
         k: v
         for k, v in spec.items()
-        if k in inspect.signature(BaseOperator.__init__).parameters.keys()
+        if k in BASE_OPERATOR_KEYS
         or k in _get_operator_parameters(operator)
         or k in _get_operator_parameters(operator.__base__)
     }
@@ -312,8 +314,7 @@ class GustyBuilder:
             user_wait_for_defaults = {
                 k: v
                 for k, v in kwargs["wait_for_defaults"].items()
-                if k in AVAILABLE_WAIT_FOR_PARAMS
-                or k in inspect.signature(BaseOperator.__init__).parameters.keys()
+                if k in AVAILABLE_WAIT_FOR_PARAMS or k in BASE_OPERATOR_KEYS
             }
             self.wait_for_defaults.update(user_wait_for_defaults)
 

--- a/gusty/importing.py
+++ b/gusty/importing.py
@@ -59,15 +59,13 @@ pairs = [
 ]
 module_dict = dict(itertools.chain(*pairs))
 
-OPERATOR_CACHE = {}
 
-
-def get_operator(operator_string):
+def get_operator(operator_string, operator_cache):
     """
     Given an operator string, determine the location of that operator and return the operator object
     """
 
-    operator = OPERATOR_CACHE.get(operator_string)
+    operator = operator_cache.get(operator_string)
     if operator:
         return operator
 
@@ -81,5 +79,5 @@ def get_operator(operator_string):
     )
 
     operator = getattr(importlib.import_module(module_name), operator_name)
-    OPERATOR_CACHE.update({operator_string: operator})
+    operator_cache.update({operator_string: operator})
     return operator

--- a/gusty/importing.py
+++ b/gusty/importing.py
@@ -59,11 +59,18 @@ pairs = [
 ]
 module_dict = dict(itertools.chain(*pairs))
 
+OPERATOR_CACHE = {}
+
 
 def get_operator(operator_string):
     """
     Given an operator string, determine the location of that operator and return the operator object
     """
+
+    operator = OPERATOR_CACHE.get(operator_string)
+    if operator:
+        return operator
+
     operator_name = get_operator_name(operator_string)
     operator_location = get_operator_location(operator_string)
 
@@ -74,4 +81,5 @@ def get_operator(operator_string):
     )
 
     operator = getattr(importlib.import_module(module_name), operator_name)
+    OPERATOR_CACHE.update({operator_string: operator})
     return operator

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gusty",
-    version="0.18.0",
+    version="0.18.1",
     author="Chris Cardillo, Michael Chow, David Robinson",
     author_email="cfcardillo23@gmail.com",
     description="Making DAG construction easier",

--- a/tests/test_custom_operators.py
+++ b/tests/test_custom_operators.py
@@ -12,7 +12,7 @@ def test_get_operator_parameters():
         def execute(self, context):
             print(self.a)
 
-    params = _get_operator_parameters(ACustomOperator)
+    params = _get_operator_parameters(ACustomOperator, {})
 
     assert "a" in params
     assert list(params) == ["self", "a", "kwargs"]
@@ -22,7 +22,7 @@ def test_get_operator_parameters_attribute():
     f = lambda a, **kwargs: BaseOperator(**kwargs)
     f._gusty_parameters = ("a",)
 
-    params = _get_operator_parameters(f)
+    params = _get_operator_parameters(f, {})
 
     assert "a" in params
     assert list(params) == ["a"]

--- a/tests/test_importing.py
+++ b/tests/test_importing.py
@@ -33,5 +33,5 @@ def test_module_fail():
 
 
 def test_get_operator():
-    operator = get_operator("airflow.operators.bash.BashOperator")
+    operator = get_operator("airflow.operators.bash.BashOperator", {})
     assert operator.__name__ == "BashOperator"


### PR DESCRIPTION
Adding constants and caching for operators and operator parameters, to improve the speed of the `build_task` function.

Run below on the main branch vs. this branch. Looks like a 50% speed-up in build time.

```python3
import timeit
from gusty import create_dag


def simple_constructor(hello=True):
    if hello:
        return "hello"
    else:
        return "goodbye"


def env_var(x):
    return x + x


def bench_dag():

    dag = create_dag(
        "tests/dags/with_metadata",
        default_args={"email": "default@gusty.com", "retries": 5},
        task_group_defaults={"prefix_group_id": True},
        wait_for_defaults={"poke_interval": 12},
        dag_constructors=[env_var, simple_constructor],
        extra_tags=["extra"],
        render_on_create=True,
    )

    return dag

ex_time = timeit.Timer(bench_dag).repeat(repeat=10, number=10)

ex_avg = sum(ex_time)/len(ex_time)

print(ex_time)

print(f"It took {ex_avg}")
```